### PR TITLE
Utilize HTML5 & CSS

### DIFF
--- a/mobile/www/css/index.css
+++ b/mobile/www/css/index.css
@@ -113,3 +113,18 @@ h1 {
     animation:fade 3000ms infinite;
     -webkit-animation:fade 3000ms infinite;
 }
+
+html, body {
+    height: 100%;
+    margin: 0;
+    padding: 20px;
+    font-family: sans-serif;
+}
+
+img {
+    padding: 0;
+    display: block;
+    margin: 0 auto;
+    max-height: 100%;
+    max-width: 100%;
+}

--- a/mobile/www/css/index.css
+++ b/mobile/www/css/index.css
@@ -119,6 +119,7 @@ html, body {
     margin: 0;
     padding: 20px;
     font-family: sans-serif;
+    text-align: center;
 }
 
 img {
@@ -127,4 +128,11 @@ img {
     margin: 0 auto;
     max-height: 100%;
     max-width: 100%;
+}
+table {
+    margin: 0 auto;
+    border: 1px solid black;
+}
+button {
+    font-size: 2em;
 }

--- a/mobile/www/css/index.css
+++ b/mobile/www/css/index.css
@@ -135,4 +135,5 @@ table {
 }
 button {
     font-size: 2em;
+    margin: 20px;
 }

--- a/mobile/www/index.html
+++ b/mobile/www/index.html
@@ -26,13 +26,13 @@
         <link rel="stylesheet" type="text/css" href="css/index.css">
         <title>Calorie Counter</title>
     </head>
-    <body style="text-align: center;">
+    <body>
         <img src="img/cc_logo.jpg" alt="Calorie_Counterlogo" height="150" width="150">
         <h2>Calorie Counter</h2>
 
         <!-- Capture and display image -->
         <div>
-            <button type="button" id="captureImage" style="font-size: 2em;">Capture Image</button>
+            <button type="button" id="captureImage">Capture Image</button>
         </div>
         <div>
             <img id="myPhoto" />
@@ -40,7 +40,7 @@
 
         <!-- Display Watson Visual Recognition response -->
         <h2>Watson sees...</h2>
-        <table id="labels" style="border: 1px solid black"></table>
+        <table id="labels"></table>
 
         <!--Display Nutritionix API response-->
         <h2>Calories</h2>

--- a/mobile/www/index.html
+++ b/mobile/www/index.html
@@ -19,16 +19,6 @@
 -->
 <html>
     <head>
-        <!--
-        Customize this policy to fit your own app's needs. For more guidance, see:
-            https://github.com/apache/cordova-plugin-whitelist/blob/master/README.md#content-security-policy
-        Some notes:
-            * gap: is required only on iOS (when using UIWebView) and is needed for JS->native communication
-            * https://ssl.gstatic.com is required only on Android and is needed for TalkBack to function properly
-            * Disables use of inline scripts in order to mitigate risk of XSS vulnerabilities. To change this:
-                * Enable inline JS: add 'unsafe-inline' to default-src
-       
-        <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src *; img-src 'self' data: content:;"> -->
         <meta http-equiv="Content-Security-Policy" content="default-src * gap: ws: https://ssl.gstatic.com;style-src * 'unsafe-inline' 'self' data: blob:;script-src * 'unsafe-inline' 'unsafe-eval' data: blob:;img-src * data: 'unsafe-inline' 'self' content:;fmedia-src mediastream;">
         <meta name="format-detection" content="telephone=no">
         <meta name="msapplication-tap-highlight" content="no">
@@ -36,41 +26,26 @@
         <link rel="stylesheet" type="text/css" href="css/index.css">
         <title>Calorie Counter</title>
     </head>
-    <body>
-        <br/><br/>
-        <center>
-            <img src="img/cc_logo.jpg" alt="Calorie_Counterlogo" height="150" width="150"> 
-            <h2>Calorie Counter</h2>
-       
-        
-            <!-- Capture Image-->
-            <br/><br/>
-            <button type="button" id="captureImage">Capture Image</button>
-            <br/><br/><br/><br/>
-           
-            
-            <!--Display captured image-->
-                
-            <img id = "myPhoto" width="350" height="300"></img>
-            <br/><br/><br/>
-        
-            <h2>Watson sees...</h2>
-        
-            <br/>
-        
-            <!--Display Watson Visual Recognition response -->
-            <table id="labels" style="border: 1px solid black"></table>
-            <br/><br/><br/>
-        
-            <h2> Calories </h2>
-            <br/>
-            </center>
-            
-            <!--Display Nutritionix API response-->
-            
-            <div class="resultContainer"></div>
-        
-             
+    <body style="text-align: center; padding: 10px; font-family: sans-serif;">
+        <img src="img/cc_logo.jpg" alt="Calorie_Counterlogo" height="150" width="150">
+        <h2>Calorie Counter</h2>
+
+        <!-- Capture and display image -->
+        <div>
+            <button type="button" id="captureImage" style="font-size: 2em;">Capture Image</button>
+        </div>
+        <div>
+            <img id="myPhoto" />
+        </div>
+
+        <!-- Display Watson Visual Recognition response -->
+        <h2>Watson sees...</h2>
+        <table id="labels" style="border: 1px solid black"></table>
+
+        <!--Display Nutritionix API response-->
+        <h2>Calories</h2>
+        <div class="resultContainer"></div>
+
         <script src="js/jquery-2.1.1.min.js"></script>
         <script type="text/javascript" src="cordova.js"></script>
         <script type="text/javascript" src="js/index.js"></script>

--- a/mobile/www/index.html
+++ b/mobile/www/index.html
@@ -26,7 +26,7 @@
         <link rel="stylesheet" type="text/css" href="css/index.css">
         <title>Calorie Counter</title>
     </head>
-    <body style="text-align: center; padding: 10px; font-family: sans-serif;">
+    <body style="text-align: center;">
         <img src="img/cc_logo.jpg" alt="Calorie_Counterlogo" height="150" width="150">
         <h2>Calorie Counter</h2>
 


### PR DESCRIPTION
I dropped a bunch of the `<br />` tags, etc, in favor of CSS, and cleaned up the page a tiny bit while working toward fixing issue #16. Captured images now appear at the correct aspect ratio, centered on the page with a similar margin (currently 20px) to what was there before.

![upper](https://i.imgur.com/Wjj9yVK.png)

![lower](https://i.imgur.com/f6SEhkj.png)