### PR TITLE
Remove deprecated metrics-tracker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.org/IBM/watson-calorie-counter.svg?branch=master)](https://travis-ci.org/IBM/watson-calorie-counter)
-![IBM Cloud Deployments](https://metrics-tracker.mybluemix.net/stats/d3843fa56f1316f27c4d4c7e7f917ef8/badge.svg)
 
 # Create a calorie counter mobile app using Watson Visual Recognition
 
@@ -35,7 +34,7 @@ This Code Pattern contains several pieces. The app server communicates with the 
 
 ## Deploy the Server Application to IBM Cloud
 
-[![Deploy to IBM Cloud](https://metrics-tracker.mybluemix.net/stats/d3843fa56f1316f27c4d4c7e7f917ef8/button.svg)](https://bluemix.net/deploy?repository=https://github.com/IBM/watson-calorie-counter)
+[![Deploy to IBM Cloud](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy?repository=https://github.com/IBM/watson-calorie-counter)
 
 1. Press the above ``Deploy to IBM Cloud`` button and then click on ``Deploy``.
 
@@ -265,27 +264,6 @@ $ export PATH=${PATH}:/users/joe/Android/sdk/platform-tools:/users/joe/Android/s
 alias |grep cordova
 ```
 If you do not see the `alias cordova=...` output from [4b](#4b-run-mobile-application-build-in-docker-container), re-execute the `alias` command above.
-
-# Privacy Notice
-
-If using the `Deploy to IBM Cloud` button some metrics are tracked, the following information is sent to a [Metrics Tracker](https://github.com/IBM/metrics-collector-service) service on each deployment:
-
-* Node.js package version
-* Node.js repository URL
-* Application Name (`application_name`)
-* Application GUID (`application_id`)
-* Application instance index number (`instance_index`)
-* Space ID (`space_id`)
-* Application Version (`application_version`)
-* Application URIs (`application_uris`)
-* Labels of bound services
-* Number of instances for each bound service and associated plan information
-
-This data is collected from the `package.json` file in the sample application and the `VCAP_APPLICATION` and `VCAP_SERVICES` environment variables in IBM Cloud and other Cloud Foundry platforms. This data is used by IBM to track metrics around deployments of sample applications to IBM IBM Cloud to measure the usefulness of our examples, so that we can continuously improve the content we offer to you. Only deployments of sample applications that include code to ping the Deployment Tracker service will be tracked.
-
-## Disabling Deployment Tracking
-
-To disable tracking, simply remove `require("metrics-tracker-client").track();` from the [server/app.js](server/app.js) file.
 
 # Links
 

--- a/server/app.js
+++ b/server/app.js
@@ -60,5 +60,3 @@ const port = process.env.PORT || process.env.VCAP_APP_PORT || 3000;
 application.listen(port, function () {
     console.log("Server running on port: %d", port);
 });
-
-require("metrics-tracker-client").track();

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,6 @@
     "dotenv": "^4.0.0",
     "express": "^4.15.x",
     "formidable": "*",
-    "metrics-tracker-client": "*",
     "vcap_services": "^0.2.0",
     "watson-developer-cloud": "^2.0.3"
   },


### PR DESCRIPTION
Remove:
Badge at top of README
Privacy Notice from Readme
Disabling Deployment Tracking from Readme
use of metric tracker in app:
i.e. `require('metrics-tracker-client').track();`
package.json for metrics-tracker

Change D2B to:
https://bluemix.net/deploy/button.png